### PR TITLE
Error fix + small update to traveling gambler chances

### DIFF
--- a/1.6/Defs/Storyteller/Incidents_Map_Misc.xml
+++ b/1.6/Defs/Storyteller/Incidents_Map_Misc.xml
@@ -10,8 +10,8 @@
     <workerClass>RimGamble.IncidentWorker_TravelingGamblerJoin</workerClass>
     <questScriptDef>TravelingGamblerArrival</questScriptDef>
     <earliestDay>0</earliestDay>
-    <baseChance>15.0</baseChance>
-    <minRefireDays>0</minRefireDays>
+    <baseChance>5.0</baseChance>
+    <minRefireDays>60</minRefireDays>
     <requireColonistsPresent>true</requireColonistsPresent>
   </IncidentDef>
   

--- a/1.6/Defs/TravelingGamblerDefs/Acceptance.xml
+++ b/1.6/Defs/TravelingGamblerDefs/Acceptance.xml
@@ -5,7 +5,7 @@
     <label>leaves</label>
     <weight>3</weight>
     <workerType>RimGamble.TravelingGambler_DepartAcceptance</workerType>
-    <triggersAfterDays>2~3</triggersAfterDays>
+    <triggersAfterDays>0.5~1.0</triggersAfterDays>
     <hasLetter>true</hasLetter>
     <letterLabel>RimGamble.AcceptanceLeavesLetterLabel</letterLabel>
     <letterDesc>RimGamble.AcceptanceLeavesLetterDesc</letterDesc>
@@ -17,7 +17,7 @@
     <label>human bomb</label>
     <weight>3</weight>
     <workerType>RimGamble.TravelingGambler_HumanBombAcceptance</workerType>
-    <triggersAfterDays>2~3</triggersAfterDays>
+    <triggersAfterDays>0.5~1.0</triggersAfterDays>
     <hasLetter>true</hasLetter>
     <letterLabel>RimGamble.AcceptanceHumanBombLetterLabel</letterLabel>
     <letterDesc>RimGamble.AcceptanceHumanBombLetterDesc</letterDesc>
@@ -29,7 +29,7 @@
     <label>sabotage</label>
     <weight>3</weight>
     <workerType>RimGamble.TravelingGamblerWorker_SabotageAcceptance</workerType>
-    <triggersAfterDays>2~3</triggersAfterDays>
+    <triggersAfterDays>0.5~1.0</triggersAfterDays>
     <hasLetter>true</hasLetter>
     <letterLabel>RimGamble.AcceptanceSabotageLetterLabel</letterLabel>
     <letterDesc>RimGamble.AcceptanceSabotageLetterDesc</letterDesc>
@@ -47,7 +47,7 @@
     <label>life of the party</label>
     <weight>3</weight>
     <workerType>RimGamble.TravelingGamblerWorker_MoodAcceptance</workerType>
-    <triggersAfterDays>2~3</triggersAfterDays>
+    <triggersAfterDays>0.5~1.0</triggersAfterDays>
     <hasLetter>true</hasLetter>
     <letterLabel>RimGamble.AcceptanceLifeOfPartyLetterLabel</letterLabel>
     <letterDesc>RimGamble.AcceptanceLifeOfPartyLetterDesc</letterDesc>
@@ -61,7 +61,7 @@
     <label>rumor spread</label>
     <weight>3</weight>
     <workerType>RimGamble.TravelingGamblerWorker_MoodAcceptance</workerType>
-    <triggersAfterDays>2~3</triggersAfterDays>
+    <triggersAfterDays>0.5~1.0</triggersAfterDays>
     <hasLetter>true</hasLetter>
     <letterLabel>RimGamble.AcceptanceRumorSpreadLetterLabel</letterLabel>
     <letterDesc>RimGamble.AcceptanceRumorSpreadLetterDesc</letterDesc>
@@ -75,7 +75,7 @@
     <label>theft accept</label>
     <weight>2</weight>
     <workerType>RimGamble.TravelingGamblerWorker_TheftAcceptance</workerType>
-    <triggersAfterDays>2~3</triggersAfterDays>
+    <triggersAfterDays>0.5~1.0</triggersAfterDays>
     <hasLetter>true</hasLetter>
     <letterLabel>RimGamble.AcceptanceTheftLetterLabel</letterLabel>
     <letterDesc>RimGamble.AcceptanceTheftLetterDesc</letterDesc>
@@ -90,7 +90,7 @@
     <label>trade caravan</label>
     <weight>3</weight>
     <workerType>RimGamble.TravelingGambler_TradeCaravanAcceptance</workerType>
-    <triggersAfterDays>2~3</triggersAfterDays>
+    <triggersAfterDays>0.5~1.0</triggersAfterDays>
     <hasLetter>true</hasLetter>
     <letterLabel>RimGamble.AcceptanceTradeCaravanLetterLabel</letterLabel>
     <letterDesc>RimGamble.AcceptanceTradeCaravanLetterDesc</letterDesc>
@@ -102,7 +102,7 @@
     <label>drop pod</label>
     <weight>3</weight>
     <workerType>RimGamble.TravelingGamblerWorker_DropPodAcceptance</workerType>
-    <triggersAfterDays>2~3</triggersAfterDays>
+    <triggersAfterDays>0.5~1.0</triggersAfterDays>
     <hasLetter>false</hasLetter>
     <!-- <letterLabel>{PAWN_nameDef} departure</letterLabel> -->
     <!-- <letterDesc>{PAWN_nameDef} thanks you for having them, they contacted someone to drop off some loot crates.</letterDesc> -->
@@ -114,7 +114,7 @@
     <label>teach skill</label>
     <weight>3</weight>
     <workerType>RimGamble.TravelingGamblerWorker_TeachSkillAcceptance</workerType>
-    <triggersAfterDays>2~3</triggersAfterDays>
+    <triggersAfterDays>0.5~1.0</triggersAfterDays>
     <hasLetter>true</hasLetter>
     <letterLabel>RimGamble.AcceptanceTeachSkillLetterLabel</letterLabel>
     <letterDesc>RimGamble.AcceptanceTeachSkillLetterDesc</letterDesc>
@@ -126,7 +126,7 @@
     <label>give inspiration</label>
     <weight>3</weight>
     <workerType>RimGamble.TravelingGamblerWorker_GiveInspirationAcceptance</workerType>
-    <triggersAfterDays>2~3</triggersAfterDays>
+    <triggersAfterDays>0.5~1.0</triggersAfterDays>
     <hasLetter>true</hasLetter>
     <letterLabel>RimGamble.AcceptanceGiveInspirationLetterLabel</letterLabel>
     <letterDesc>RimGamble.AcceptanceGiveInspirationLetterDesc</letterDesc>
@@ -138,7 +138,7 @@
     <label>ask join</label>
     <weight>3</weight>
     <workerType>RimGamble.TravelingGamblerWorker_AskJoinAcceptance</workerType>
-    <triggersAfterDays>2~3</triggersAfterDays>
+    <triggersAfterDays>0.5~1.0</triggersAfterDays>
 
     <clearLord>false</clearLord>
 

--- a/1.6/Source/RimGamble/HarmonyPatches.cs
+++ b/1.6/Source/RimGamble/HarmonyPatches.cs
@@ -32,7 +32,7 @@ namespace RimGamble
             if (selPawn.IsColonist)
             {
                 // Adding custom float menu
-                List<FloatMenuOption> modifiedOptions = new List<FloatMenuOption>(__result);
+                List<FloatMenuOption> modifiedOptions = __result != null ? new List<FloatMenuOption>(__result) : new List<FloatMenuOption>();
 
                 // Add custom float menu option
                 FloatMenuOption option = null;
@@ -158,6 +158,11 @@ namespace RimGamble
             {
                 Pawn_TravelingGamblerTracker tracker = TravelingGamblerTrackerManager.GetTracker(__instance);
                 Scribe_Deep.Look(ref tracker, "travelinggambler", __instance);
+                
+                if (Scribe.mode == LoadSaveMode.LoadingVars && tracker != null)
+                {
+                    TravelingGamblerTrackerManager.AddTracker(__instance, tracker);
+                }
             }
         }
     }

--- a/1.6/Source/RimGamble/RimGambleManager.cs
+++ b/1.6/Source/RimGamble/RimGambleManager.cs
@@ -299,11 +299,13 @@ public class RimGambleManager : GameComponent
     public RimGambleManager()
     {
         Instance = this;
+        TravelingGamblerTrackerManager.Reset();
     }
 
     public RimGambleManager(Game game)
     {
         Instance = this;
+        TravelingGamblerTrackerManager.Reset();
     }
 
     public override void ExposeData()

--- a/1.6/Source/RimGamble/TravelingGambler/Alert_TravelingGamblerTimeout.cs
+++ b/1.6/Source/RimGamble/TravelingGambler/Alert_TravelingGamblerTimeout.cs
@@ -25,7 +25,7 @@ namespace RimGamble
                         if (TravelingGamblerTrackerManager.HasTracker(pawn))
                         {
                             var tracker = TravelingGamblerTrackerManager.GetTracker(pawn);
-                            if (tracker != null && tracker.IsOnEntryLord &&
+                            if (tracker != null && tracker.IsOnEntryLord && !tracker.IsAccepted &&
                                 GenTicks.TicksAbs >= tracker.timeoutAt - WarningTicks)
                             {
                                 gamblers.Add(pawn);

--- a/1.6/Source/RimGamble/TravelingGambler/Pawn_TravelingGamblerTracker.cs
+++ b/1.6/Source/RimGamble/TravelingGambler/Pawn_TravelingGamblerTracker.cs
@@ -16,7 +16,7 @@ namespace RimGamble
 
         private bool useAlternativeLetter;
 
-        private bool IsAccepted;
+        public bool IsAccepted;
 
         public TravelingGamblerFormKindDef form;
 
@@ -130,6 +130,11 @@ namespace RimGamble
         public void AcceptTravleingGambler()
         {
             IsAccepted = true;
+            if (Pawn.Map != null)
+            {
+                ClearLord();
+                LordMaker.MakeNewLord(Pawn.Faction, new LordJob_DefendPoint(Pawn.Position), Pawn.Map, new List<Pawn> { Pawn });
+            }
         }
 
         public void SetAlternativeLetter(bool setAlternativeLetter)
@@ -164,6 +169,11 @@ namespace RimGamble
 
         public void Tick()
         {
+            if (acceptance == null || form == null || rejection == null || aggressive == null)
+            {
+               InitializeDefaults();
+            }
+
             if (IsAccepted)
             {
                 AcceptedTick();
@@ -172,6 +182,27 @@ namespace RimGamble
             {
                 CheckTriggersTick();
             }
+        }
+
+        private void InitializeDefaults()
+        {
+            if (form == null)
+            {
+                form = DefDatabase<TravelingGamblerFormKindDef>.AllDefs.RandomElement();
+            }
+            if (acceptance == null)
+            {
+                acceptance = DefDatabase<TravelingGamblerAcceptanceDef>.AllDefs.RandomElement();
+            }
+            if (rejection == null)
+            {
+                rejection = DefDatabase<TravelingGamblerRejectionDef>.AllDefs.RandomElement();
+            }
+            if (aggressive == null)
+            {
+                aggressive = DefDatabase<TravelingGamblerAggressiveDef>.AllDefs.RandomElement();
+            }
+            Notify_Created();
         }
 
         private void CheckTriggersTick()

--- a/1.6/Source/RimGamble/TravelingGambler/TravelingGamblerTrackerManager.cs
+++ b/1.6/Source/RimGamble/TravelingGambler/TravelingGamblerTrackerManager.cs
@@ -11,11 +11,19 @@ namespace RimGamble
     {
         private static Dictionary<Pawn, Pawn_TravelingGamblerTracker> trackers = new Dictionary<Pawn, Pawn_TravelingGamblerTracker>();
 
-        public static void AddTracker(Pawn pawn)
+        public static void Reset()
+        {
+            trackers.Clear();
+        }
+
+        public static void AddTracker(Pawn pawn, Pawn_TravelingGamblerTracker tracker = null)
         {
             if (!trackers.ContainsKey(pawn))
             {
-                trackers[pawn] = new Pawn_TravelingGamblerTracker(pawn);
+                if (tracker == null)
+                    trackers[pawn] = new Pawn_TravelingGamblerTracker(pawn);
+                else
+                    trackers[pawn] = tracker;
             }
         }
 

--- a/1.6/Source/RimGamble/TravelingGambler/TravelingGamblerUtility.cs
+++ b/1.6/Source/RimGamble/TravelingGambler/TravelingGamblerUtility.cs
@@ -217,6 +217,11 @@ namespace RimGamble
             TravelingGamblerAggressiveDef aggressive = GetRandom(DefDatabase<TravelingGamblerAggressiveDef>.AllDefsListForReading, combatPoints, requires, exclude);
             TravelingGamblerRejectionDef rejection = GetRandom(DefDatabase<TravelingGamblerRejectionDef>.AllDefsListForReading, combatPoints, requires, exclude);
             TravelingGamblerAcceptanceDef acceptance = GetRandom(DefDatabase<TravelingGamblerAcceptanceDef>.AllDefsListForReading, combatPoints, requires, exclude);
+            if (acceptance == null)
+            {
+                Log.Warning("[RimGamble] Failed to find valid acceptance behavior. Defaulting to first available.");
+                 acceptance = DefDatabase<TravelingGamblerAcceptanceDef>.AllDefsListForReading.RandomElement();
+            }
             exclude.Clear();
             requires.Clear();
             return GenerateAndSpawn(travelingGamblerFormKindDef, aggressive, rejection, acceptance, map);


### PR DESCRIPTION
This pull request introduces several improvements and bug fixes to the Traveling Gambler system, focusing on reliability, event timing, and state management. The most significant changes include resetting tracker state on game load, ensuring proper initialization of gambler behaviors, and adjusting event timings for more responsive gameplay.

**Reliability and State Management Improvements:**

* Added a `Reset` method to `TravelingGamblerTrackerManager` and called it in the `RimGambleManager` constructor to ensure tracker state is cleared on new game or load, preventing stale data issues. [[1]](diffhunk://#diff-9182e7258e387f22a799eccdefe220fd64bcd97b5b0dbf33223faf325bdf4b4dL14-R26) [[2]](diffhunk://#diff-05622af06ed165568254cb6110c04f5931df0837918c48e6534c965cb2406ef5R302-R308)
* Improved tracker loading logic to re-register trackers after loading saved games, ensuring all gamblers are properly tracked.

**Initialization and Default Handling:**

* Added `InitializeDefaults` method in `Pawn_TravelingGamblerTracker` to ensure all behavior definitions (`form`, `acceptance`, `rejection`, `aggressive`) are set, preventing null reference errors and improving robustness. [[1]](diffhunk://#diff-95791532319624cf799118e55a3aa671ee5a141487810d9cae36cf4072a8cdedR172-R176) [[2]](diffhunk://#diff-95791532319624cf799118e55a3aa671ee5a141487810d9cae36cf4072a8cdedR187-R207)
* Added fallback logic in `TravelingGamblerUtility.GenerateAndSpawn` to default to a random acceptance behavior if none is found, logging a warning for easier debugging.

**Gameplay and Event Timing Adjustments:**

* Reduced the base chance for the Traveling Gambler event and increased the minimum refire days, making the event less frequent and more balanced.
* Shortened the trigger time for various acceptance events from 2–3 days to 0.5–1.0 days, making responses and consequences occur sooner after gambler acceptance. [[1]](diffhunk://#diff-08be61cfcae4f27f4d284cc5b3284684edb65ff0380df838edd5ef53c42d4debL8-R8) [[2]](diffhunk://#diff-08be61cfcae4f27f4d284cc5b3284684edb65ff0380df838edd5ef53c42d4debL20-R20) [[3]](diffhunk://#diff-08be61cfcae4f27f4d284cc5b3284684edb65ff0380df838edd5ef53c42d4debL32-R32) [[4]](diffhunk://#diff-08be61cfcae4f27f4d284cc5b3284684edb65ff0380df838edd5ef53c42d4debL50-R50) [[5]](diffhunk://#diff-08be61cfcae4f27f4d284cc5b3284684edb65ff0380df838edd5ef53c42d4debL64-R64) [[6]](diffhunk://#diff-08be61cfcae4f27f4d284cc5b3284684edb65ff0380df838edd5ef53c42d4debL78-R78) [[7]](diffhunk://#diff-08be61cfcae4f27f4d284cc5b3284684edb65ff0380df838edd5ef53c42d4debL93-R93) [[8]](diffhunk://#diff-08be61cfcae4f27f4d284cc5b3284684edb65ff0380df838edd5ef53c42d4debL105-R105) [[9]](diffhunk://#diff-08be61cfcae4f27f4d284cc5b3284684edb65ff0380df838edd5ef53c42d4debL117-R117) [[10]](diffhunk://#diff-08be61cfcae4f27f4d284cc5b3284684edb65ff0380df838edd5ef53c42d4debL129-R129) [[11]](diffhunk://#diff-08be61cfcae4f27f4d284cc5b3284684edb65ff0380df838edd5ef53c42d4debL141-R141)

**Bug Fixes and Code Quality:**

* Fixed potential null reference in float menu patch by checking for null before creating the modified options list.
* Made `IsAccepted` public in `Pawn_TravelingGamblerTracker` for correct access and state checks.
* Improved alert logic to only warn about gamblers who have not yet been accepted.
* Ensured proper lord assignment when a gambler is accepted, improving in-game behavior consistency.

These changes collectively improve the reliability, responsiveness, and maintainability of the Traveling Gambler feature.